### PR TITLE
Fix Constructor for JerseyConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Setup Jersey Application:
 ```java
 public class JerseyConfig extends ResourceConfig {
    
-   public TestJerseyConfig() {
+   public JerseyConfig() {
            setApplicationName("test");
            register(JacksonFeature.class);
            register(LoggingFeature.class);


### PR DESCRIPTION
JerseyConfig class has constructor name `TestJerseyConfig` instead of `JerseyConfig` which cause a Compilation error.